### PR TITLE
Fix Grid2 imports and type-safe donut mutation handling

### DIFF
--- a/src/components/employee/employee-edit/employee-edit.tsx
+++ b/src/components/employee/employee-edit/employee-edit.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { CloseOutlined } from "@mui/icons-material";
-import { Grid2 as Grid } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 
 import { useBntTranslate } from "hooks/use-bnt-translate";
 import { texts_c } from "services/localization/texts";

--- a/src/entities/donut/model/use-donut.ts
+++ b/src/entities/donut/model/use-donut.ts
@@ -2,13 +2,18 @@ import { PutDonutsByIdApiResponse } from "services/api/bonuts-api";
 import { donutsApi } from "services/api/extended/donuts-api";
 import { useUpdateDonutMutation } from "services/api/injected-api";
 import { useAppDispatch } from "services/redux/store/store";
-import { isBlank, present } from "shared/lib/type-guards";
+import { isBlank } from "shared/lib/type-guards";
 
 import { ApiTags } from "@/shared/api";
 
 import { useProfile } from "@/entities/profile";
 
+import { SerializedError } from "@reduxjs/toolkit";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import type { TDonut } from "@/types/model";
+
+type TDonutUpdateResult = { data: PutDonutsByIdApiResponse } | { error: FetchBaseQueryError | SerializedError };
+const hasData = (result: TDonutUpdateResult): result is { data: PutDonutsByIdApiResponse } => "data" in result;
 
 export const useDonut = () => {
 	const [updateDonut] = useUpdateDonutMutation();
@@ -26,7 +31,7 @@ export const useDonut = () => {
 
 			dispatch(donutsApi.util.invalidateTags([ApiTags.Donuts]));
 
-			if (present(res.data)) {
+			if (hasData(res)) {
 				options?.onSuccess?.(res.data);
 			}
 			return res;

--- a/src/entities/profile/ui/profile-edit.tsx
+++ b/src/entities/profile/ui/profile-edit.tsx
@@ -1,4 +1,4 @@
-import { Grid2 as Grid } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 
 import { useProfile } from "@/entities/profile";
 


### PR DESCRIPTION
### Motivation
- MUI v6 exports `Grid2` as a default export path, so using the named `Grid2 as Grid` from `@mui/material` caused incorrect imports in edit screens.
- The RTK mutation result in `useDonut` was accessed unsafely (`res.data`) without narrowing, risking runtime errors when the mutation yielded an error.

### Description
- Replace `import { Grid2 as Grid } from "@mui/material"` with `import Grid from "@mui/material/Grid2"` in `EmployeeEdit` and `ProfileEdit` to use the correct MUI export.
- Add a union type `TDonutUpdateResult` and a type guard `hasData` for mutation results, and use `if (hasData(res))` before accessing `res.data` in `useDonut`.
- Import `SerializedError` and `FetchBaseQueryError` to model the error branch of the mutation result and remove the now-unused `present` helper.

### Testing
- Ran `./node_modules/.bin/tsc --noEmit` and it completed successfully.
- Ran `./node_modules/.bin/biome check` (fixes applied for import ordering) and no errors remained.
- Ran `./node_modules/.bin/vitest run` and test suite passed (1 test file, 1 test).
- Pre-commit hooks executed `lint-staged` and `vitest run` during commit and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699750ad381c832fbae306d9c45bf42c)