### PR TITLE
Centralize tenant resolution with `resolveCurrentTenant` and use in auth flow

### DIFF
--- a/src/services/redux/slice/auth-slice.ts
+++ b/src/services/redux/slice/auth-slice.ts
@@ -1,4 +1,5 @@
 import type { TAuthState } from "@/shared/model/auth";
+import { resolveCurrentTenant } from "@/shared/model/auth/resolve-current-tenant";
 
 import { bonutsApi } from "../../api/bonuts-api";
 
@@ -30,17 +31,13 @@ const slice = createSlice({
 			})
 			.addMatcher(bonutsApi.endpoints.postDemoAuthenticate.matchFulfilled, (state, action) => {
 				state.token = action.payload.auth_token;
-				if (action.payload.tenants.length === 1) {
-					state.tenant = action.payload.tenants[0]?.name || "";
-				}
+				state.tenant = resolveCurrentTenant(action.payload);
 				state.isAuthenticated = true;
 				state.isAuthenticating = false;
 			})
 			.addMatcher(bonutsApi.endpoints.postRefreshToken.matchFulfilled, (state, action) => {
 				state.token = action.payload.auth_token;
-				if (action.payload.tenants.length === 1) {
-					state.tenant = action.payload.tenants[0]?.name || "";
-				}
+				state.tenant = resolveCurrentTenant(action.payload);
 				state.isAuthenticated = true;
 				state.isAuthenticating = false;
 			})
@@ -55,9 +52,7 @@ const slice = createSlice({
 			})
 			.addMatcher(bonutsApi.endpoints.postAuthenticate.matchFulfilled, (state, action) => {
 				state.token = action.payload.auth_token;
-				if (action.payload.tenants.length === 1) {
-					state.tenant = action.payload.tenants[0]?.name || "";
-				}
+				state.tenant = resolveCurrentTenant(action.payload);
 				state.isAuthenticated = true;
 				state.isAuthenticating = false;
 			})

--- a/src/shared/model/auth/resolve-current-tenant.ts
+++ b/src/shared/model/auth/resolve-current-tenant.ts
@@ -1,0 +1,16 @@
+export type TenantSource = {
+	currentTenant?: string | null;
+	tenants?: Array<{ name?: string | null } | null> | null;
+};
+
+export const resolveCurrentTenant = (source: TenantSource): string => {
+	if (source.currentTenant) {
+		return source.currentTenant;
+	}
+
+	if (source.tenants?.length === 1) {
+		return source.tenants[0]?.name || "";
+	}
+
+	return "";
+};

--- a/src/shared/model/auth/use-auth.ts
+++ b/src/shared/model/auth/use-auth.ts
@@ -12,6 +12,8 @@ import { authActions } from "services/redux/slice/auth-slice";
 import { useAppDispatch, useAppSelector } from "services/redux/store/store";
 import { storage } from "shared/lib/localStorage";
 
+import { resolveCurrentTenant } from "./resolve-current-tenant";
+
 // const MAX_RETRY_NUMBER = 3;
 
 // TODO: now we use localStorage for saving auth_token. We should remove it as soon as new backend will be deployed since it is unsave and we should use only cookie for jwt
@@ -27,6 +29,11 @@ export function useAuth() {
 	const { getValue, setValue } = storage;
 	const [isAuthLoading, setIsAuthLoading] = useState(true);
 
+	const persistAuth = (payload: { auth_token: string; currentTenant?: string; tenants: Array<{ name?: string | null }> }) => {
+		setValue<string>("auth_token", payload.auth_token);
+		setValue<string>("tenant", resolveCurrentTenant(payload));
+	};
+
 	const getAuth = (): TAuth => {
 		return {
 			token: getValue("auth_token") || "",
@@ -41,14 +48,7 @@ export function useAuth() {
 				body: { email: credentials.body.email.trim(), password: credentials.body.password },
 			};
 			const payload = await postAuthenticate(trimmedCredentials).unwrap();
-			let current_tenant = "";
-			if (payload.currentTenant) {
-				current_tenant = payload.currentTenant;
-			} else if (payload.tenants.length === 1) {
-				current_tenant = payload.tenants[0]?.name || "";
-			}
-			setValue<string>("auth_token", payload.auth_token);
-			setValue<string>("tenant", current_tenant);
+			persistAuth(payload);
 		} catch (err) {
 			// eslint-disable-next-line no-console
 			console.log(err);
@@ -58,14 +58,7 @@ export function useAuth() {
 	const demoSignIn = async () => {
 		try {
 			const payload = await postDemoAuthenticate().unwrap();
-			let current_tenant = "";
-			if (payload.currentTenant) {
-				current_tenant = payload.currentTenant;
-			} else if (payload.tenants.length === 1) {
-				current_tenant = payload.tenants[0]?.name || "";
-			}
-			setValue<string>("auth_token", payload.auth_token);
-			setValue<string>("tenant", current_tenant);
+			persistAuth(payload);
 		} catch (err) {
 			// eslint-disable-next-line no-console
 			console.log(err);


### PR DESCRIPTION
### Motivation

- Consolidate tenant-selection logic used after authentication to avoid duplication and subtle inconsistencies. 
- Ensure both Redux state updates and localStorage persistence derive the current tenant from a single source of truth. 
- Prepare for clearer handling of `currentTenant` vs `tenants` response fields across auth endpoints. 

### Description

- Add a new utility `resolveCurrentTenant` (`src/shared/model/auth/resolve-current-tenant.ts`) that returns the current tenant string from a response object. 
- Replace inline tenant resolution in `auth-slice` (`src/services/redux/slice/auth-slice.ts`) with calls to `resolveCurrentTenant` for all authentication-related fulfillment handlers. 
- Introduce `persistAuth` in `use-auth` (`src/shared/model/auth/use-auth.ts`) that writes `auth_token` and tenant to storage using `resolveCurrentTenant`, and refactor `signIn` and `demoSignIn` to use it. 

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ec13db20832f8fef23acba687f08)