### PR TITLE
Add animated auth-loading screen in SwitchRoutes

### DIFF
--- a/src/app/ui/switch-routes.tsx
+++ b/src/app/ui/switch-routes.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
+import { CircularProgress, Stack } from "@mui/material";
 
 import _ from "lodash";
 
 import { useLocationTyped } from "hooks/use-location-typed";
 
 import { type TAuthState, useAuth, useCurrentProfile } from "@/shared/model/auth";
+import { BntTypography } from "@/shared/ui/typography/typography";
 
 import type { TModalConfig } from "@/entities/modal";
 
@@ -64,7 +66,12 @@ function SwitchRoutes({ routes }: ISwitchRoutesProps) {
 	}, [routes]);
 
 	if (isAuthLoading) {
-		return <div>Checking auth...</div>;
+		return (
+			<Stack alignItems="center" justifyContent="center" spacing={2} sx={{ minHeight: "60vh" }}>
+				<CircularProgress size={48} />
+				<BntTypography variant="h6">Checking auth...</BntTypography>
+			</Stack>
+		);
 	}
 
 	const hasAccess = (route: TRoute<BntRoutes>) => {

--- a/src/app/ui/switch-routes.tsx
+++ b/src/app/ui/switch-routes.tsx
@@ -7,7 +7,7 @@ import _ from "lodash";
 import { useLocationTyped } from "hooks/use-location-typed";
 
 import { type TAuthState, useAuth, useCurrentProfile } from "@/shared/model/auth";
-import { BntTypography } from "@/shared/ui/typography/typography";
+import { BntTypography } from "@/shared/ui/typography";
 
 import type { TModalConfig } from "@/entities/modal";
 


### PR DESCRIPTION
### Motivation
- `SwitchRoutes` previously returned a bare `Checking auth...` text while auth was being verified, resulting in a poor loading UX.  
- Provide a clear, centered animated loader so users see immediate feedback during authentication checks.

### Description
- Replaced the `if (isAuthLoading)` branch that returned `<div>Checking auth...</div>` with a centered MUI `CircularProgress` and supporting `BntTypography` inside a `Stack` in `src/app/ui/switch-routes.tsx`.  
- Added necessary imports for `CircularProgress`, `Stack`, and `BntTypography` and organized imports in the same file.  
- No routing, auth-check, or access-control logic was changed.

### Testing
- Ran `npx biome check src/app/ui/switch-routes.tsx` which completed successfully after organizing imports.  
- Ran `vitest run` (executed via the pre-commit hook) and the test suite passed.  
- A full `yarn lint` run initially showed unrelated repository-wide lint diagnostics, but the modified file was formatted and linted as part of the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a02d98008832fa625f69e8ce83bd8)