### PR TITLE
test: add Cypress test for redirect to dashboard after login

### DIFF
--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -8,4 +8,23 @@ describe("Login page", () => {
 		cy.get("#password").should("be.visible");
 		cy.get('button[type="submit"]').should("be.visible");
 	});
+
+	it("redirects to dashboard after successful login", () => {
+		cy.intercept("POST", "**/authenticate", {
+			statusCode: 200,
+			body: {
+				auth_token: "test-auth-token",
+				currentTenant: "test-tenant",
+				tenants: [{ name: "test-tenant" }],
+			},
+		}).as("loginRequest");
+
+		cy.visit("/login");
+		cy.get("#email").type("test@example.com");
+		cy.get("#password").type("password123");
+		cy.get('button[type="submit"]').click();
+
+		cy.wait("@loginRequest");
+		cy.url().should("eq", `${Cypress.config("baseUrl")}/`);
+	});
 });


### PR DESCRIPTION
### Motivation
- Add an end-to-end test to verify that a successful authentication redirects the user from the `Login` page to the dashboard (`/`).

### Description
- Added a Cypress test in `cypress/e2e/login.cy.ts` that stubs `POST **/authenticate`, fills the login form, submits it, waits for the auth request, and asserts final URL is the dashboard (`/`).

### Testing
- Attempted to run `yarn cypress run --spec cypress/e2e/login.cy.ts`, but the run failed in this environment because Corepack could not download Yarn (network/proxy 403), so the test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a016ea2738832f8742605044744f5e)