### PR TITLE
Add bonuts-client-workflow skill docs and implementation guide

### DIFF
--- a/skills/bonuts-client-workflow/SKILL.md
+++ b/skills/bonuts-client-workflow/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: bonuts-client-workflow
+description: Use this skill when working on the Bonuts frontend (feature changes, bug fixes, API wiring, localization, routing, or tests) in the bonuts-client repository.
+---
+
+# Bonuts Client Workflow
+
+Use this skill for requests like:
+- "Fix a bug in Bonuts UI"
+- "Add a new Bonuts page or form"
+- "Wire a new backend endpoint in Bonuts"
+- "Update Bonuts translations"
+
+## Quick project map
+
+- App shell/provider composition: `src/components/app/app.tsx`
+- Entry + Redux provider: `src/index.tsx`
+- Redux store/history: `src/services/redux/store/store.ts`
+- RTK Query base API: `src/services/api/empty-api.ts`
+- OpenAPI-generated endpoints: `src/services/api/bonuts-api.ts`
+- Manual API overrides/enhancements: `src/services/api/injected-api.ts`
+- Route config/menu building: `src/routes/config/routes-config.ts`, `src/routes/get-menu-routes.ts`
+- Localized text dictionaries: `src/services/localization/texts/`
+- Shared reusable UI primitives: `src/shared/`
+- Feature/page implementations: `src/pages/`, `src/components/`, `src/features/`
+
+For deeper conventions and checklists, read `references/bonuts-implementation-guide.md`.
+
+## Standard execution flow
+
+1. **Locate the vertical slice**
+   - Start from route/page, then identify dependent API hooks/selectors/components.
+2. **Prefer existing Bonuts primitives**
+   - Reuse `src/shared/*` inputs, buttons, cards, table helpers, and modal/loader providers before creating new primitives.
+3. **API work pattern**
+   - If endpoint already exists in `bonuts-api.ts`, consume generated hook.
+   - If endpoint is missing and OpenAPI has it, run `yarn generate-api`.
+   - For multipart or custom behavior, add overrides in `injected-api.ts`.
+   - If generated API lacks desired `providesTags`/`invalidatesTags`, add tags manually via `bonutsApi.enhanceEndpoints(...)` in custom API layer code.
+4. **Localization first**
+   - Add/adjust translation keys in `src/services/localization/texts/*` instead of hardcoded UI strings.
+5. **FSD migration awareness**
+   - Bonuts is migrating to FSD; place new code in FSD-friendly boundaries and avoid increasing legacy cross-layer coupling.
+   - In FSD code, import across slices only through public APIs such as `@/shared` or `@/entity`; use relative imports only for internal imports within the same slice.
+6. **Validate changes**
+   - Run targeted tests first, then `yarn test:withoutWatch` for broader coverage when practical.
+   - Run `yarn lint` for type/lint safety before finalizing.
+
+## Guardrails
+
+- Treat `bonuts-api.ts` as OpenAPI-generated output; avoid manual edits in generated sections.
+- In FSD modules, import other slices via their public API (for example `@/shared` or `@/entity`), and use relative imports only inside one slice.
+- Keep auth-aware API behavior in `empty-api.ts` patterns (`Authorization` header, `credentials: include`).
+- Preserve existing store composition and middleware stack in `store.ts`.
+- Follow existing naming/style in nearby files; avoid introducing alternate architectural patterns.

--- a/skills/bonuts-client-workflow/references/bonuts-implementation-guide.md
+++ b/skills/bonuts-client-workflow/references/bonuts-implementation-guide.md
@@ -1,0 +1,54 @@
+# Bonuts implementation guide
+
+## 1) Architecture essentials
+
+- React 18 + Vite + TypeScript app.
+- State and server cache use Redux Toolkit + RTK Query.
+- Routing uses `redux-first-history` (`HistoryRouter` in `App`).
+- Theme, locale, snackbar, loading, and app context providers are composed in `src/components/app/app.tsx`.
+- Bonuts is migrating to FSD; prefer changes that move toward clearer feature/entity/shared boundaries.
+- In FSD code, cross-slice imports should go through public APIs such as `@/shared` or `@/entity`; use relative imports only for modules inside the same slice.
+
+## 2) Domain model clues in this codebase
+
+Bonuts frontend centers around tenants, profiles, donuts, circles, events, invitations, requests, ties, scheduler, and account operations (visible in generated API endpoints and page folders).
+
+When implementing behavior, find the matching API adapter and page module first:
+- API layer: `src/services/api/extended/*`, `src/services/api/bonuts-api.ts`, `src/services/api/injected-api.ts`
+- Data mapping: `src/services/adaptor/*`
+- UI pages/features: `src/pages/*`, `src/features/*`
+
+## 3) Practical change recipes
+
+### Add a new API-backed UI action
+
+1. Check for existing endpoint hook in `bonuts-api.ts`.
+2. If absent, regenerate API from OpenAPI using `yarn generate-api`.
+3. If request format is special (e.g., `FormData`), add an override in `injected-api.ts`.
+4. If generated endpoints need caching tags, add them manually with `bonutsApi.enhanceEndpoints(...)` (do not patch generated blocks directly).
+5. Consume hook in target component/page and keep request/response adaptation in adaptor files.
+
+### Add a new page behavior
+
+1. Update relevant route config in `src/routes/config/routes-config.ts`.
+2. Add/modify page component in `src/pages/<page-name>/`.
+3. Reuse shared components from `src/shared/`.
+4. Add localization keys and use translation hooks instead of literals.
+5. When feasible, implement in a way that supports ongoing FSD migration (reduce coupling and keep boundaries explicit).
+6. In FSD areas, import from other slices only through public APIs like `@/shared` or `@/entity`; keep relative imports internal to a single slice.
+
+### Add or update localized text
+
+1. Add key in correct file under `src/services/localization/texts/`.
+2. Ensure key is available through locale setup (`en`/`ru` dictionaries).
+3. Replace hardcoded UI text with localization key usage.
+
+## 4) Validation checklist
+
+Run this default sequence:
+
+1. `yarn test:withoutWatch`
+2. `yarn lint`
+3. `yarn build`
+
+If time is limited, at minimum run checks relevant to touched files and note limitations.


### PR DESCRIPTION
### Motivation

- Provide a consolidated workflow and reference for contributors working on the Bonuts frontend, including project map, API patterns, localization guidance, and FSD migration notes. 
- Define standard execution flow and guardrails to reduce duplicate decisions and preserve existing architectural patterns.

### Description

- Add `skills/bonuts-client-workflow/SKILL.md` with usage guidance, a quick project map, standard execution flow for feature/API/localization work, and guardrails. 
- Add `skills/bonuts-client-workflow/references/bonuts-implementation-guide.md` containing architecture essentials, domain model clues, practical change recipes (API-backed actions, pages, localization), and a validation checklist referencing `yarn generate-api`, `yarn test:withoutWatch`, and `yarn lint`. 

### Testing

- No automated tests were run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9c79af950832fbf400a7979eab91e)